### PR TITLE
[WIP] #18 Bump to serde v1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ test = false
 [dependencies]
 dtoa = "0.4.0"
 itoa = "0.3.0"
-serde = "0.9.3"
+serde = "1.0.0"
 url = "1.0.0"

--- a/src/ser/pair.rs
+++ b/src/ser/pair.rs
@@ -103,7 +103,7 @@ impl<'target, Target> ser::Serializer for PairSerializer<'target, Target>
 
     fn serialize_unit_variant(self,
                               _name: &'static str,
-                              _variant_index: usize,
+                              _variant_index: u32,
                               _variant: &'static str)
                               -> Result<(), Error> {
         Err(Error::unsupported_pair())
@@ -120,7 +120,7 @@ impl<'target, Target> ser::Serializer for PairSerializer<'target, Target>
     fn serialize_newtype_variant<T: ?Sized + ser::Serialize>
         (self,
          _name: &'static str,
-         _variant_index: usize,
+         _variant_index: u32,
          _variant: &'static str,
          _value: &T)
          -> Result<(), Error> {
@@ -143,12 +143,6 @@ impl<'target, Target> ser::Serializer for PairSerializer<'target, Target>
         Err(Error::unsupported_pair())
     }
 
-    fn serialize_seq_fixed_size(self,
-                                _len: usize)
-                                -> Result<Self::SerializeSeq, Error> {
-        Err(Error::unsupported_pair())
-    }
-
     fn serialize_tuple(self, len: usize) -> Result<Self, Error> {
         if len == 2 {
             Ok(self)
@@ -167,7 +161,7 @@ impl<'target, Target> ser::Serializer for PairSerializer<'target, Target>
     fn serialize_tuple_variant
         (self,
          _name: &'static str,
-         _variant_index: usize,
+         _variant_index: u32,
          _variant: &'static str,
          _len: usize)
          -> Result<Self::SerializeTupleVariant, Error> {
@@ -190,7 +184,7 @@ impl<'target, Target> ser::Serializer for PairSerializer<'target, Target>
     fn serialize_struct_variant
         (self,
          _name: &'static str,
-         _variant_index: usize,
+         _variant_index: u32,
          _variant: &'static str,
          _len: usize)
          -> Result<Self::SerializeStructVariant, Error> {

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -113,7 +113,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
 
     fn serialize_unit_variant(self,
                               _name: &'static str,
-                              _variant_index: usize,
+                              _variant_index: u32,
                               variant: &'static str)
                               -> Result<S::Ok, Error> {
         self.sink.serialize_static_str(variant.into())
@@ -130,7 +130,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
     fn serialize_newtype_variant<T: ?Sized + ser::Serialize>
         (self,
          _name: &'static str,
-         _variant_index: usize,
+         _variant_index: u32,
          _variant: &'static str,
          _value: &T)
          -> Result<S::Ok, Error> {
@@ -153,13 +153,6 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         Err(self.sink.unsupported())
     }
 
-
-    fn serialize_seq_fixed_size(self,
-                                _len: usize)
-                                -> Result<Self::SerializeSeq, Error> {
-        Err(self.sink.unsupported())
-    }
-
     fn serialize_tuple(self,
                        _len: usize)
                        -> Result<Self::SerializeTuple, Error> {
@@ -176,7 +169,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
     fn serialize_tuple_variant
         (self,
          _name: &'static str,
-         _variant_index: usize,
+         _variant_index: u32,
          _variant: &'static str,
          _len: usize)
          -> Result<Self::SerializeTupleVariant, Error> {
@@ -199,7 +192,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
     fn serialize_struct_variant
         (self,
          _name: &'static str,
-         _variant_index: usize,
+         _variant_index: u32,
          _variant: &'static str,
          _len: usize)
          -> Result<Self::SerializeStructVariant, Error> {

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -23,3 +23,11 @@ fn deserialize_reader() {
     assert_eq!(serde_urlencoded::from_reader(b"first=23&last=42" as &[_]),
                Ok(result));
 }
+
+#[test]
+fn deserialize_bools() {
+    let result = vec![("first".to_owned(), true), ("last".to_owned(), false)];
+    
+    assert_eq!(serde_urlencoded::from_str("first=true&last=false"), 
+               Ok(result));
+}


### PR DESCRIPTION
As of right now, all the deserialization tests fail. Per @dtolnay, this is because implicit conversions from String were removed as part of the 0.9-to-1.0 transition. I'm not sure how to access the values in the deserializer to manually attempt parsing them.

See issue #18 