### PR TITLE
Add method `to_string_sorted_by_name`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target
 Cargo.lock
+.idea
+*.iml

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,4 @@ pub mod ser;
 #[doc(inline)]
 pub use de::{Deserializer, from_bytes, from_reader, from_str};
 #[doc(inline)]
-pub use ser::{Serializer, to_string};
+pub use ser::{Serializer, to_string , to_string_sorted_by_name};

--- a/src/ser/encoder.rs
+++ b/src/ser/encoder.rs
@@ -1,0 +1,62 @@
+use url::form_urlencoded::Serializer;
+
+///abstract layer for encoder.
+pub trait UrlEncoder{
+    /// add name/value pair
+    fn append_pair(&mut self , name : &str , value : &str);
+
+    fn finish(self) -> String;
+}
+
+
+pub struct FormUrlEncoder {
+    url_encoder: Box<Serializer<String>>,
+}
+
+pub struct CachedEncoder {
+    cache : Vec<(String , String)>
+}
+
+impl FormUrlEncoder {
+
+    pub fn new() -> Self {
+        FormUrlEncoder {url_encoder: Box::new(Serializer::new(String::new())) }
+    }
+}
+
+impl UrlEncoder for FormUrlEncoder {
+
+    fn append_pair(&mut self , name : &str , value : &str){
+        (*self.url_encoder).append_pair(name , value);
+    }
+
+    fn finish(mut self) -> String {
+        (*self.url_encoder).finish()
+    }
+}
+
+impl CachedEncoder {
+
+    pub fn new() -> CachedEncoder{
+        CachedEncoder{cache : Vec::new()}
+    }
+
+    pub fn sort_by_name(&mut self) {
+        self.cache.sort_by(|item_1 , item_2| item_1.0.cmp(&item_2.0));
+    }
+}
+
+impl UrlEncoder for CachedEncoder {
+
+    fn append_pair(&mut self , name : &str , value : &str) {
+        self.cache.push((name.to_string() , value.to_string()));
+    }
+
+    fn finish(self) -> String {
+        let mut serializer = Serializer::new(String::new());
+        for (name , value) in self.cache.into_iter() {
+            serializer.append_pair(&name , &value);
+        }
+        serializer.finish()
+    }
+}

--- a/src/ser/pair.rs
+++ b/src/ser/pair.rs
@@ -5,18 +5,15 @@ use ser::value::ValueSink;
 use serde::ser;
 use std::borrow::Cow;
 use std::mem;
-use url::form_urlencoded::Serializer as UrlEncodedSerializer;
-use url::form_urlencoded::Target as UrlEncodedTarget;
+use super::encoder::UrlEncoder;
 
-pub struct PairSerializer<'target, Target: 'target + UrlEncodedTarget> {
-    urlencoder: &'target mut UrlEncodedSerializer<Target>,
+pub struct PairSerializer<'target> {
+    urlencoder: &'target mut UrlEncoder,
     state: PairState,
 }
 
-impl<'target, Target> PairSerializer<'target, Target>
-    where Target: 'target + UrlEncodedTarget,
-{
-    pub fn new(urlencoder: &'target mut UrlEncodedSerializer<Target>) -> Self {
+impl<'target> PairSerializer<'target> {
+    pub fn new(urlencoder: &'target mut UrlEncoder) -> Self {
         PairSerializer {
             urlencoder: urlencoder,
             state: PairState::WaitingForKey,
@@ -24,9 +21,7 @@ impl<'target, Target> PairSerializer<'target, Target>
     }
 }
 
-impl<'target, Target> ser::Serializer for PairSerializer<'target, Target>
-    where Target: 'target + UrlEncodedTarget,
-{
+impl<'target> ser::Serializer for PairSerializer<'target> {
     type Ok = ();
     type Error = Error;
     type SerializeSeq = ser::Impossible<(), Error>;
@@ -198,9 +193,7 @@ impl<'target, Target> ser::Serializer for PairSerializer<'target, Target>
     }
 }
 
-impl<'target, Target> ser::SerializeTuple for PairSerializer<'target, Target>
-    where Target: 'target + UrlEncodedTarget,
-{
+impl<'target> ser::SerializeTuple for PairSerializer<'target> {
     type Ok = ();
     type Error = Error;
 

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -2,20 +2,15 @@ use ser::Error;
 use ser::part::{PartSerializer, Sink};
 use serde::ser::Serialize;
 use std::str;
-use url::form_urlencoded::Serializer as UrlEncodedSerializer;
-use url::form_urlencoded::Target as UrlEncodedTarget;
+use super::encoder::UrlEncoder;
 
-pub struct ValueSink<'key, 'target, Target>
-    where Target: 'target + UrlEncodedTarget,
-{
-    urlencoder: &'target mut UrlEncodedSerializer<Target>,
+pub struct ValueSink<'key, 'target> {
+    urlencoder: &'target mut UrlEncoder,
     key: &'key str,
 }
 
-impl<'key, 'target, Target> ValueSink<'key, 'target, Target>
-    where Target: 'target + UrlEncodedTarget,
-{
-    pub fn new(urlencoder: &'target mut UrlEncodedSerializer<Target>,
+impl<'key, 'target> ValueSink<'key, 'target>{
+    pub fn new(urlencoder: &'target mut UrlEncoder,
                key: &'key str)
                -> Self {
         ValueSink {
@@ -25,9 +20,7 @@ impl<'key, 'target, Target> ValueSink<'key, 'target, Target>
     }
 }
 
-impl<'key, 'target, Target> Sink for ValueSink<'key, 'target, Target>
-    where Target: 'target + UrlEncodedTarget,
-{
+impl<'key, 'target> Sink for ValueSink<'key, 'target> {
     type Ok = ();
 
     fn serialize_str(self, value: &str) -> Result<(), Error> {


### PR DESCRIPTION
Add method `to_string_sorted_by_name`. It was usually generated url parameters for signature. 
# For Example
```
sorted_url_params = to_string_sorted_by_name(...);
signature = md5(sorted_url_params  +  salt);
final_url_param = sorted_url_params + "&signature=" + signature;
```