### PR TITLE
Deserialize () from input without key/value pairs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_urlencoded"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/nox/serde_urlencoded"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This crate works with Cargo and can be found on
 
 ```toml
 [dependencies]
-serde_urlencoded = "0.4.2"
+serde_urlencoded = "0.5.1"
 ```
 
 [crates.io]: https://crates.io/crates/serde_urlencoded

--- a/src/de.rs
+++ b/src/de.rs
@@ -110,6 +110,13 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
         visitor.visit_seq(self.inner)
     }
 
+    fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+        where V:  de::Visitor<'de>,
+    {
+        self.inner.end()?;
+        visitor.visit_unit()
+    }
+
     forward_to_deserialize_any! {
         bool
         u8
@@ -125,7 +132,6 @@ impl<'de> de::Deserializer<'de> for Deserializer<'de> {
         char
         str
         string
-        unit
         option
         bytes
         byte_buf

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -32,3 +32,11 @@ fn deserialize_option() {
     ];
     assert_eq!(serde_urlencoded::from_str("first=23&last=42"), Ok(result));
 }
+
+#[test]
+fn deserialize_unit() {
+    assert_eq!(serde_urlencoded::from_str(""), Ok(()));
+    assert_eq!(serde_urlencoded::from_str("&"), Ok(()));
+    assert_eq!(serde_urlencoded::from_str("&&"), Ok(()));
+    assert!(serde_urlencoded::from_str::<()>("first=23").is_err());
+}


### PR DESCRIPTION
Currently there's no input that can be deserialized to `()`, this changes the crate to support deserializing strings without any key/value pair to a `()` (such as the empty string, or just `"&"`).

Would be great if you could release a patch for this, I have a project that needs this behavior.

EDIT: To expand on my use case, I have a trait which parses the body of an HTTP Request into a type (e.g. for a `POST` request). However, this is abstract over HTTP methods, and its expected to be able to parse an empty body (e.g. from a `GET` request) into `()`.