### PR TITLE
Support deserializing a (keyword) string into a unit-only enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_urlencoded"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/nox/serde_urlencoded"
@@ -20,3 +20,6 @@ dtoa = "0.4.0"
 itoa = "0.4.0"
 serde = "1.0.0"
 url = "1.0.0"
+
+[dev-dependencies]
+serde_derive = "1.0"

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -1,4 +1,6 @@
 extern crate serde_urlencoded;
+#[macro_use]
+extern crate serde_derive;
 
 #[test]
 fn deserialize_bytes() {
@@ -39,4 +41,22 @@ fn deserialize_unit() {
     assert_eq!(serde_urlencoded::from_str("&"), Ok(()));
     assert_eq!(serde_urlencoded::from_str("&&"), Ok(()));
     assert!(serde_urlencoded::from_str::<()>("first=23").is_err());
+}
+
+#[derive(Deserialize, Debug, PartialEq, Eq)]
+enum X {
+    A,
+    B,
+    C,
+}
+
+#[test]
+fn deserialize_unit_enum() {
+    let result = vec![
+        ("one".to_owned(), X::A),
+        ("two".to_owned(), X::B),
+        ("three".to_owned(), X::C)
+    ];
+
+    assert_eq!(serde_urlencoded::from_str("one=A&two=B&three=C"), Ok(result));
 }

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -1,4 +1,6 @@
 extern crate serde_urlencoded;
+#[macro_use]
+extern crate serde_derive;
 
 #[test]
 fn serialize_option_map_int() {
@@ -31,4 +33,18 @@ fn serialize_map_bool() {
 
     assert_eq!(serde_urlencoded::to_string(params),
                Ok("one=true&two=false".to_owned()));
+}
+
+#[derive(Serialize)]
+enum X {
+    A,
+    B,
+    C,
+}
+
+#[test]
+fn serialize_unit_enum() {
+    let params = &[("one", X::A), ("two", X::B), ("three", X::C)];
+    assert_eq!(serde_urlencoded::to_string(params),
+               Ok("one=A&two=B&three=C".to_owned()));
 }


### PR DESCRIPTION
This adds support for deserializing a structure such as:

```rust
#[derive(Serialize, Deserialize, Debug)]
#[serde(rename_all = "camelCase")]
enum SortOrder {
    Asc,
    Desc,
}

#[derive(Serialize, Deserialize, Debug)]
struct SearchOptions {
    sort: SortOrder,
}
```

This is already supported for serialization (and I've added a test case for the existing support as part of this PR), but attempting to deserialize the string `"sort=asc"` would result in the error:

```
invalid type: string "asc", expected enum SortOrder
```

I've made a sample in the playground of the way this is handled in `serde_urlencoded` vs `serde_json`: https://play.rust-lang.org/?gist=75fc1e5bbbc1eec29a472373d47488a0&version=stable

This brings the behaviour in line with the way `serde_json` currently handles this case, which I hope is appropriate. Happy to tweak the behaviour if there's a better way to handle it.