### PR TITLE
Fix struct newtype deserialization (and add tests)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_urlencoded"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/nox/serde_urlencoded"

--- a/src/de.rs
+++ b/src/de.rs
@@ -208,6 +208,16 @@ impl<'de> de::Deserializer<'de> for Part<'de> {
         visitor.visit_enum(ValueEnumAccess(self.0))
     }
 
+    fn deserialize_newtype_struct<V>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+        where V: de::Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
     forward_to_deserialize_any! {
         char
         str
@@ -216,7 +226,6 @@ impl<'de> de::Deserializer<'de> for Part<'de> {
         bytes
         byte_buf
         unit_struct
-        newtype_struct
         tuple_struct
         struct
         identifier

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -2,6 +2,17 @@ extern crate serde_urlencoded;
 #[macro_use]
 extern crate serde_derive;
 
+#[derive(Deserialize, Debug, PartialEq)]
+struct NewType<T>(T);
+
+#[test]
+fn deserialize_newtype_i32() {
+    let result = vec![("field".to_owned(), NewType(11))];
+
+    assert_eq!(serde_urlencoded::from_str("field=11"),
+               Ok(result));
+}
+
 #[test]
 fn deserialize_bytes() {
     let result = vec![("first".to_owned(), 23), ("last".to_owned(), 42)];

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -2,6 +2,18 @@ extern crate serde_urlencoded;
 #[macro_use]
 extern crate serde_derive;
 
+#[derive(Serialize)]
+struct NewType<T>(T);
+
+#[test]
+fn serialize_newtype_i32() {
+    let params = &[("field", Some(NewType(11))),];
+    assert_eq!(
+        serde_urlencoded::to_string(params),
+        Ok("field=11".to_owned())
+    );
+}
+
 #[test]
 fn serialize_option_map_int() {
     let params = &[("first", Some(23)), ("middle", None), ("last", Some(42))];


### PR DESCRIPTION
Fixes #41

I only had to fix the deserializer - the serialization already works. So now they work the same way - you can serialize something and then deserialize it losslessly. 

I also added tests for serialization and deserialization. Let me know if there's anything you'd like changed.