### PR TITLE
Pass input by ref

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -27,7 +27,10 @@ use url::form_urlencoded::Target as UrlEncodedTarget;
 ///     serde_urlencoded::to_string(meal),
 ///     Ok("bread=baguette&cheese=comt%C3%A9&meat=ham&fat=butter".to_owned()));
 /// ```
-pub fn to_string<T: ser::Serialize>(input: T) -> Result<String, Error> {
+pub fn to_string<T>(input: &T) -> Result<String, Error>
+where
+    T: ser::Serialize + ?Sized,
+{
     let mut urlencoder = UrlEncodedSerializer::new("".to_owned());
     input.serialize(Serializer::new(&mut urlencoder))?;
     Ok(urlencoder.finish())

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -73,3 +73,32 @@ fn serialize_unit_enum() {
         Ok("one=A&two=B&three=C".to_owned())
     );
 }
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+enum OtherComplex<'a> {
+    SomeString(&'a str),
+}
+
+#[derive(Serialize)]
+struct Complex<'a> {
+    a: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    b: Option<&'a str>,
+    #[serde(flatten)]
+    c: OtherComplex<'a>,
+}
+
+#[test]
+fn serialize_complex() {
+    let complex = Complex {
+        a: 23,
+        b: None,
+        c: OtherComplex::SomeString("a string"),
+    };
+
+    assert_eq!(
+        serde_urlencoded::to_string(&complex),
+        Ok("a=23&someString=a+string".to_owned())
+    );
+}


### PR DESCRIPTION
`to_string` does not need to take the serialization input by value, changing it to pass by reference
aligns with how most other serde crates work.

Also adds a serde test that is an example of the use case that spurred this change.