### PR TITLE
Expose lifetimes in UrlEncodedSerializer

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -42,13 +42,13 @@ pub fn to_string<T: ser::Serialize>(input: T) -> Result<String, Error> {
 ///   unit structs and unit variants.
 ///
 /// * Newtype structs defer to their inner values.
-pub struct Serializer<'output, Target: 'output + UrlEncodedTarget> {
-    urlencoder: &'output mut UrlEncodedSerializer<'static, Target>,
+pub struct Serializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+    urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
 }
 
-impl<'output, Target: 'output + UrlEncodedTarget> Serializer<'output, Target> {
+impl<'input, 'output, Target: 'output + UrlEncodedTarget> Serializer<'input, 'output, Target> {
     /// Returns a new `Serializer`.
-    pub fn new(urlencoder: &'output mut UrlEncodedSerializer<'static, Target>) -> Self {
+    pub fn new(urlencoder: &'output mut UrlEncodedSerializer<'input, Target>) -> Self {
         Serializer {
             urlencoder: urlencoder,
         }
@@ -95,62 +95,62 @@ impl ser::Error for Error {
 }
 
 /// Sequence serializer.
-pub struct SeqSerializer<'output, Target: 'output + UrlEncodedTarget> {
-    urlencoder: &'output mut UrlEncodedSerializer<'static, Target>,
+pub struct SeqSerializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+    urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
 }
 
 /// Tuple serializer.
 ///
 /// Mostly used for arrays.
-pub struct TupleSerializer<'output, Target: 'output + UrlEncodedTarget> {
-    urlencoder: &'output mut UrlEncodedSerializer<'static, Target>,
+pub struct TupleSerializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+    urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
 }
 
 /// Tuple struct serializer.
 ///
 /// Never instantiated, tuple structs are not supported.
-pub struct TupleStructSerializer<'output, T: 'output + UrlEncodedTarget> {
-    inner: ser::Impossible<&'output mut UrlEncodedSerializer<'static, T>, Error>,
+pub struct TupleStructSerializer<'input, 'output, T: 'output + UrlEncodedTarget> {
+    inner: ser::Impossible<&'output mut UrlEncodedSerializer<'input, T>, Error>,
 }
 
 /// Tuple variant serializer.
 ///
 /// Never instantiated, tuple variants are not supported.
-pub struct TupleVariantSerializer<'output, T: 'output + UrlEncodedTarget> {
-    inner: ser::Impossible<&'output mut UrlEncodedSerializer<'static, T>, Error>,
+pub struct TupleVariantSerializer<'input, 'output, T: 'output + UrlEncodedTarget> {
+    inner: ser::Impossible<&'output mut UrlEncodedSerializer<'input, T>, Error>,
 }
 
 /// Map serializer.
-pub struct MapSerializer<'output, Target: 'output + UrlEncodedTarget> {
-    urlencoder: &'output mut UrlEncodedSerializer<'static, Target>,
+pub struct MapSerializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+    urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
     key: Option<Cow<'static, str>>,
 }
 
 /// Struct serializer.
-pub struct StructSerializer<'output, Target: 'output + UrlEncodedTarget> {
-    urlencoder: &'output mut UrlEncodedSerializer<'static, Target>,
+pub struct StructSerializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+    urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
 }
 
 /// Struct variant serializer.
 ///
 /// Never instantiated, struct variants are not supported.
-pub struct StructVariantSerializer<'output, T: 'output + UrlEncodedTarget> {
-    inner: ser::Impossible<&'output mut UrlEncodedSerializer<'static, T>, Error>,
+pub struct StructVariantSerializer<'input, 'output, T: 'output + UrlEncodedTarget> {
+    inner: ser::Impossible<&'output mut UrlEncodedSerializer<'input, T>, Error>,
 }
 
-impl<'output, Target> ser::Serializer for Serializer<'output, Target>
+impl<'input, 'output, Target> ser::Serializer for Serializer<'input, 'output, Target>
 where
     Target: 'output + UrlEncodedTarget,
 {
-    type Ok = &'output mut UrlEncodedSerializer<'static, Target>;
+    type Ok = &'output mut UrlEncodedSerializer<'input, Target>;
     type Error = Error;
-    type SerializeSeq = SeqSerializer<'output, Target>;
-    type SerializeTuple = TupleSerializer<'output, Target>;
-    type SerializeTupleStruct = TupleStructSerializer<'output, Target>;
-    type SerializeTupleVariant = TupleVariantSerializer<'output, Target>;
-    type SerializeMap = MapSerializer<'output, Target>;
-    type SerializeStruct = StructSerializer<'output, Target>;
-    type SerializeStructVariant = StructVariantSerializer<'output, Target>;
+    type SerializeSeq = SeqSerializer<'input, 'output, Target>;
+    type SerializeTuple = TupleSerializer<'input, 'output, Target>;
+    type SerializeTupleStruct = TupleStructSerializer<'input, 'output, Target>;
+    type SerializeTupleVariant = TupleVariantSerializer<'input, 'output, Target>;
+    type SerializeMap = MapSerializer<'input, 'output, Target>;
+    type SerializeStruct = StructSerializer<'input, 'output, Target>;
+    type SerializeStructVariant = StructVariantSerializer<'input, 'output, Target>;
 
     /// Returns an error.
     fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Error> {
@@ -352,11 +352,11 @@ where
     }
 }
 
-impl<'output, Target> ser::SerializeSeq for SeqSerializer<'output, Target>
+impl<'input, 'output, Target> ser::SerializeSeq for SeqSerializer<'input, 'output, Target>
 where
     Target: 'output + UrlEncodedTarget,
 {
-    type Ok = &'output mut UrlEncodedSerializer<'static, Target>;
+    type Ok = &'output mut UrlEncodedSerializer<'input, Target>;
     type Error = Error;
 
     fn serialize_element<T: ?Sized + ser::Serialize>(
@@ -371,11 +371,11 @@ where
     }
 }
 
-impl<'output, Target> ser::SerializeTuple for TupleSerializer<'output, Target>
+impl<'input, 'output, Target> ser::SerializeTuple for TupleSerializer<'input, 'output, Target>
 where
     Target: 'output + UrlEncodedTarget,
 {
-    type Ok = &'output mut UrlEncodedSerializer<'static, Target>;
+    type Ok = &'output mut UrlEncodedSerializer<'input, Target>;
     type Error = Error;
 
     fn serialize_element<T: ?Sized + ser::Serialize>(
@@ -390,12 +390,12 @@ where
     }
 }
 
-impl<'output, Target> ser::SerializeTupleStruct
-    for TupleStructSerializer<'output, Target>
+impl<'input, 'output, Target> ser::SerializeTupleStruct
+    for TupleStructSerializer<'input, 'output, Target>
 where
     Target: 'output + UrlEncodedTarget,
 {
-    type Ok = &'output mut UrlEncodedSerializer<'static, Target>;
+    type Ok = &'output mut UrlEncodedSerializer<'input, Target>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized + ser::Serialize>(
@@ -410,12 +410,12 @@ where
     }
 }
 
-impl<'output, Target> ser::SerializeTupleVariant
-    for TupleVariantSerializer<'output, Target>
+impl<'input, 'output, Target> ser::SerializeTupleVariant
+    for TupleVariantSerializer<'input, 'output, Target>
 where
     Target: 'output + UrlEncodedTarget,
 {
-    type Ok = &'output mut UrlEncodedSerializer<'static, Target>;
+    type Ok = &'output mut UrlEncodedSerializer<'input, Target>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized + ser::Serialize>(
@@ -430,11 +430,11 @@ where
     }
 }
 
-impl<'output, Target> ser::SerializeMap for MapSerializer<'output, Target>
+impl<'input, 'output, Target> ser::SerializeMap for MapSerializer<'input, 'output, Target>
 where
     Target: 'output + UrlEncodedTarget,
 {
-    type Ok = &'output mut UrlEncodedSerializer<'static, Target>;
+    type Ok = &'output mut UrlEncodedSerializer<'input, Target>;
     type Error = Error;
 
     fn serialize_entry<
@@ -483,11 +483,11 @@ where
     }
 }
 
-impl<'output, Target> ser::SerializeStruct for StructSerializer<'output, Target>
+impl<'input, 'output, Target> ser::SerializeStruct for StructSerializer<'input, 'output, Target>
 where
     Target: 'output + UrlEncodedTarget,
 {
-    type Ok = &'output mut UrlEncodedSerializer<'static, Target>;
+    type Ok = &'output mut UrlEncodedSerializer<'input, Target>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized + ser::Serialize>(
@@ -504,12 +504,12 @@ where
     }
 }
 
-impl<'output, Target> ser::SerializeStructVariant
-    for StructVariantSerializer<'output, Target>
+impl<'input, 'output, Target> ser::SerializeStructVariant
+    for StructVariantSerializer<'input, 'output, Target>
 where
     Target: 'output + UrlEncodedTarget,
 {
-    type Ok = &'output mut UrlEncodedSerializer<'static, Target>;
+    type Ok = &'output mut UrlEncodedSerializer<'input, Target>;
     type Error = Error;
 
     fn serialize_field<T: ?Sized + ser::Serialize>(

--- a/src/ser/pair.rs
+++ b/src/ser/pair.rs
@@ -8,16 +8,16 @@ use std::mem;
 use url::form_urlencoded::Serializer as UrlEncodedSerializer;
 use url::form_urlencoded::Target as UrlEncodedTarget;
 
-pub struct PairSerializer<'target, Target: 'target + UrlEncodedTarget> {
-    urlencoder: &'target mut UrlEncodedSerializer<'static, Target>,
+pub struct PairSerializer<'input, 'target, Target: 'target + UrlEncodedTarget> {
+    urlencoder: &'target mut UrlEncodedSerializer<'input, Target>,
     state: PairState,
 }
 
-impl<'target, Target> PairSerializer<'target, Target>
+impl<'input, 'target, Target> PairSerializer<'input, 'target, Target>
 where
     Target: 'target + UrlEncodedTarget,
 {
-    pub fn new(urlencoder: &'target mut UrlEncodedSerializer<'static, Target>) -> Self {
+    pub fn new(urlencoder: &'target mut UrlEncodedSerializer<'input, Target>) -> Self {
         PairSerializer {
             urlencoder: urlencoder,
             state: PairState::WaitingForKey,
@@ -25,7 +25,7 @@ where
     }
 }
 
-impl<'target, Target> ser::Serializer for PairSerializer<'target, Target>
+impl<'input, 'target, Target> ser::Serializer for PairSerializer<'input, 'target, Target>
 where
     Target: 'target + UrlEncodedTarget,
 {
@@ -200,7 +200,7 @@ where
     }
 }
 
-impl<'target, Target> ser::SerializeTuple for PairSerializer<'target, Target>
+impl<'input, 'target, Target> ser::SerializeTuple for PairSerializer<'input, 'target, Target>
 where
     Target: 'target + UrlEncodedTarget,
 {

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -5,20 +5,20 @@ use std::str;
 use url::form_urlencoded::Serializer as UrlEncodedSerializer;
 use url::form_urlencoded::Target as UrlEncodedTarget;
 
-pub struct ValueSink<'key, 'target, Target>
+pub struct ValueSink<'input, 'key, 'target, Target>
 where
     Target: 'target + UrlEncodedTarget,
 {
-    urlencoder: &'target mut UrlEncodedSerializer<'static, Target>,
+    urlencoder: &'target mut UrlEncodedSerializer<'input, Target>,
     key: &'key str,
 }
 
-impl<'key, 'target, Target> ValueSink<'key, 'target, Target>
+impl<'input, 'key, 'target, Target> ValueSink<'input, 'key, 'target, Target>
 where
     Target: 'target + UrlEncodedTarget,
 {
     pub fn new(
-        urlencoder: &'target mut UrlEncodedSerializer<'static, Target>,
+        urlencoder: &'target mut UrlEncodedSerializer<'input, Target>,
         key: &'key str,
     ) -> Self {
         ValueSink {
@@ -28,7 +28,7 @@ where
     }
 }
 
-impl<'key, 'target, Target> Sink for ValueSink<'key, 'target, Target>
+impl<'input, 'key, 'target, Target> Sink for ValueSink<'input, 'key, 'target, Target>
 where
     Target: 'target + UrlEncodedTarget,
 {


### PR DESCRIPTION
Forcing UrlEncodedSerializer to have a 'static lifetime is unnecessarily
restrictive and breaks a downstream dependency, reqwest. Thread a new
lifetime through to fix the problem.