### PR TITLE
Remove deprecated Error::description and Error::cause

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -72,15 +72,8 @@ impl fmt::Display for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Custom(ref msg) => msg,
-            Error::Utf8(ref err) => error::Error::description(err),
-        }
-    }
-
-    /// The lower-level cause of this error, in the case of a `Utf8` error.
-    fn cause(&self) -> Option<&error::Error> {
+    /// The lower-level source of this error, in the case of a `Utf8` error.
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             Error::Custom(_) => None,
             Error::Utf8(ref err) => Some(err),


### PR DESCRIPTION
`Error::description` has been documented as soft-deprecated since 1.27.0 (17 months ago). It is going to be hard-deprecated soon(nightly/1.42). `Error::cause` has been documented as deprecated since 1.27.0, while `Error::source` was introduced.

This PR:
- Removes all implementations of `description` in error type
- Replaces `cause` with `source`

Related PR: https://github.com/rust-lang/rust/pull/66919