### PR TITLE
Allow serialization of unit type

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -230,9 +230,9 @@ where
         Err(Error::top_level())
     }
 
-    /// Returns an error.
+    /// Returns `Ok`.
     fn serialize_unit(self) -> Result<Self::Ok, Error> {
-        Err(Error::top_level())
+        Ok(self.urlencoder)
     }
 
     /// Returns `Ok`.

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -83,3 +83,8 @@ fn deserialize_unit_enum() {
         Ok(result)
     );
 }
+
+#[test]
+fn deserialize_unit_type() {
+    assert_eq!(serde_urlencoded::from_str(""), Ok(()));
+}

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -81,3 +81,8 @@ struct Unit;
 fn serialize_unit_struct() {
     assert_eq!(serde_urlencoded::to_string(Unit), Ok("".to_owned()));
 }
+
+#[test]
+fn serialize_unit_type() {
+    assert_eq!(serde_urlencoded::to_string(()), Ok("".to_owned()));
+}


### PR DESCRIPTION
That changes provides support for unit type serialization.

It may looks like it doesn't make sense to serialize `()`. Unfortunately that kind of serialization may be necessary for generic structures where one of generic argument may be `()`.

Closes #69 