### PR TITLE
Fix clippy recommendations and compiler warnings

### DIFF
--- a/src/ser/key.rs
+++ b/src/ser/key.rs
@@ -38,7 +38,7 @@ where
     End: for<'key> FnOnce(Key<'key>) -> Result<Ok, Error>,
 {
     pub fn new(end: End) -> Self {
-        KeySink { end: end }
+        KeySink { end }
     }
 }
 

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -478,7 +478,7 @@ where
         value: &T,
     ) -> Result<(), Error> {
         {
-            let key = self.key.as_ref().ok_or_else(|| Error::no_key())?;
+            let key = self.key.as_ref().ok_or_else(Error::no_key)?;
             let value_sink = value::ValueSink::new(self.urlencoder, &key);
             value.serialize(part::PartSerializer::new(value_sink))?;
         }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -50,7 +50,7 @@ impl<'input, 'output, Target: 'output + UrlEncodedTarget> Serializer<'input, 'ou
     /// Returns a new `Serializer`.
     pub fn new(urlencoder: &'output mut UrlEncodedSerializer<'input, Target>) -> Self {
         Serializer {
-            urlencoder: urlencoder,
+            urlencoder,
         }
     }
 }

--- a/src/ser/pair.rs
+++ b/src/ser/pair.rs
@@ -19,7 +19,7 @@ where
 {
     pub fn new(urlencoder: &'target mut UrlEncodedSerializer<'input, Target>) -> Self {
         PairSerializer {
-            urlencoder: urlencoder,
+            urlencoder,
             state: PairState::WaitingForKey,
         }
     }
@@ -229,7 +229,7 @@ where
                 if result.is_ok() {
                     self.state = PairState::Done;
                 } else {
-                    self.state = PairState::WaitingForValue { key: key };
+                    self.state = PairState::WaitingForValue { key };
                 }
                 result
             },

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -10,7 +10,7 @@ pub struct PartSerializer<S> {
 
 impl<S: Sink> PartSerializer<S> {
     pub fn new(sink: S) -> Self {
-        PartSerializer { sink: sink }
+        PartSerializer { sink }
     }
 }
 

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -110,7 +110,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<S::Ok, Error> {
-        self.sink.serialize_static_str(name.into())
+        self.sink.serialize_static_str(name)
     }
 
     fn serialize_unit_variant(
@@ -119,7 +119,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<S::Ok, Error> {
-        self.sink.serialize_static_str(variant.into())
+        self.sink.serialize_static_str(variant)
     }
 
     fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -22,8 +22,8 @@ where
         key: &'key str,
     ) -> Self {
         ValueSink {
-            urlencoder: urlencoder,
-            key: key,
+            urlencoder,
+            key,
         }
     }
 }


### PR DESCRIPTION
Implemented some clippy recommendations and fixed a few compiler warnings.

The two compiler warnings I left are

```
warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
  --> src/ser/mod.rs:78:37
   |
78 |             Error::Utf8(ref err) => error::Error::description(err),
   |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```

I'm not sure how to fix this without changing the function return (currently &str) since, to my knowledge, there's no other way to access the description as a reference to self.

```
warning: trait objects without an explicit `dyn` are deprecated
  --> src/ser/mod.rs:83:32
   |
83 |     fn cause(&self) -> Option<&error::Error> {
   |                                ^^^^^^^^^^^^ help: use `dyn`: `dyn error::Error`
   |
   = note: `#[warn(bare_trait_objects)]` on by default
```

This is fixed in #70 so I didn't want to create a conflict.