### PR TITLE
Use the new form_urlencoded crate instead of url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ test = false
 
 [dependencies]
 dtoa = "0.4.0"
+form_urlencoded = "1.0.0"
 itoa = "0.4.0"
 serde = "1.0.0"
-url = "2.0.0"
 
 [dev-dependencies]
 serde_derive = "1.0"

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,12 +1,12 @@
 //! Deserialization support for the `application/x-www-form-urlencoded` format.
 
+use form_urlencoded::parse;
+use form_urlencoded::Parse as UrlEncodedParse;
 use serde::de::value::MapDeserializer;
 use serde::de::Error as de_Error;
 use serde::de::{self, IntoDeserializer};
 use std::borrow::Cow;
 use std::io::Read;
-use url::form_urlencoded::parse;
-use url::form_urlencoded::Parse as UrlEncodedParse;
 
 #[doc(inline)]
 pub use serde::de::value::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,10 @@
 #![warn(unused_extern_crates)]
 
 extern crate dtoa;
+extern crate form_urlencoded;
 extern crate itoa;
 #[macro_use]
 extern crate serde;
-extern crate url;
 
 pub mod de;
 pub mod ser;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -5,13 +5,13 @@ mod pair;
 mod part;
 mod value;
 
+use form_urlencoded::Serializer as UrlEncodedSerializer;
+use form_urlencoded::Target as UrlEncodedTarget;
 use serde::ser;
 use std::borrow::Cow;
 use std::error;
 use std::fmt;
 use std::str;
-use url::form_urlencoded::Serializer as UrlEncodedSerializer;
-use url::form_urlencoded::Target as UrlEncodedTarget;
 
 /// Serializes a value into a `application/x-www-form-urlencoded` `String` buffer.
 ///

--- a/src/ser/pair.rs
+++ b/src/ser/pair.rs
@@ -1,3 +1,5 @@
+use form_urlencoded::Serializer as UrlEncodedSerializer;
+use form_urlencoded::Target as UrlEncodedTarget;
 use ser::key::KeySink;
 use ser::part::PartSerializer;
 use ser::value::ValueSink;
@@ -5,8 +7,6 @@ use ser::Error;
 use serde::ser;
 use std::borrow::Cow;
 use std::mem;
-use url::form_urlencoded::Serializer as UrlEncodedSerializer;
-use url::form_urlencoded::Target as UrlEncodedTarget;
 
 pub struct PairSerializer<'input, 'target, Target: 'target + UrlEncodedTarget> {
     urlencoder: &'target mut UrlEncodedSerializer<'input, Target>,

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -1,9 +1,9 @@
+use form_urlencoded::Serializer as UrlEncodedSerializer;
+use form_urlencoded::Target as UrlEncodedTarget;
 use ser::part::{PartSerializer, Sink};
 use ser::Error;
 use serde::ser::Serialize;
 use std::str;
-use url::form_urlencoded::Serializer as UrlEncodedSerializer;
-use url::form_urlencoded::Target as UrlEncodedTarget;
 
 pub struct ValueSink<'input, 'key, 'target, Target>
 where


### PR DESCRIPTION
The `form_urlencoded` crate was created today to move out some of `url`s functionality for crates that don't need the rest, such as this one: https://github.com/servo/rust-url/pull/607

Dep graph before:

![before](https://user-images.githubusercontent.com/951129/85187153-db797080-b29d-11ea-99c0-cfa228aa62bd.png)

Dep graph after:

![after](https://user-images.githubusercontent.com/951129/85187157-e46a4200-b29d-11ea-8505-018e67025191.png)