### PR TITLE
Update to edition 2018 & clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "`x-www-form-urlencoded` meets Serde"
 categories = ["encoding", "web-programming"]
 keywords = ["serde", "serialization", "urlencoded"]
 exclude = ["/.travis.yml", "/bors.toml"]
+edition = "2018"
 
 [badges]
 travis-ci = {repository = "nox/serde_urlencoded"}

--- a/src/de.rs
+++ b/src/de.rs
@@ -5,6 +5,7 @@ use form_urlencoded::Parse as UrlEncodedParse;
 use serde::de::value::MapDeserializer;
 use serde::de::Error as de_Error;
 use serde::de::{self, IntoDeserializer};
+use serde::forward_to_deserialize_any;
 use std::borrow::Cow;
 use std::io::Read;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,16 +2,10 @@
 
 #![warn(unused_extern_crates)]
 
-extern crate form_urlencoded;
-extern crate itoa;
-extern crate ryu;
-#[macro_use]
-extern crate serde;
-
 pub mod de;
 pub mod ser;
 
 #[doc(inline)]
-pub use de::{from_bytes, from_reader, from_str, Deserializer};
+pub use crate::de::{from_bytes, from_reader, from_str, Deserializer};
 #[doc(inline)]
-pub use ser::{to_string, Serializer};
+pub use crate::ser::{to_string, Serializer};

--- a/src/ser/key.rs
+++ b/src/ser/key.rs
@@ -38,7 +38,7 @@ where
     End: for<'key> FnOnce(Key<'key>) -> Result<Ok, Error>,
 {
     pub fn new(end: End) -> Self {
-        KeySink { end: end }
+        KeySink { end }
     }
 }
 

--- a/src/ser/key.rs
+++ b/src/ser/key.rs
@@ -1,5 +1,5 @@
-use ser::part::Sink;
-use ser::Error;
+use crate::ser::part::Sink;
+use crate::ser::Error;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::ops::Deref;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -49,9 +49,7 @@ pub struct Serializer<'input, 'output, Target: UrlEncodedTarget> {
 impl<'input, 'output, Target: 'output + UrlEncodedTarget> Serializer<'input, 'output, Target> {
     /// Returns a new `Serializer`.
     pub fn new(urlencoder: &'output mut UrlEncodedSerializer<'input, Target>) -> Self {
-        Serializer {
-            urlencoder: urlencoder,
-        }
+        Serializer { urlencoder }
     }
 }
 
@@ -478,7 +476,7 @@ where
         value: &T,
     ) -> Result<(), Error> {
         {
-            let key = self.key.as_ref().ok_or_else(|| Error::no_key())?;
+            let key = self.key.as_ref().ok_or_else(Error::no_key)?;
             let value_sink = value::ValueSink::new(self.urlencoder, &key);
             value.serialize(part::PartSerializer::new(value_sink))?;
         }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -42,7 +42,7 @@ pub fn to_string<T: ser::Serialize>(input: T) -> Result<String, Error> {
 ///   unit structs and unit variants.
 ///
 /// * Newtype structs defer to their inner values.
-pub struct Serializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+pub struct Serializer<'input, 'output, Target: UrlEncodedTarget> {
     urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
 }
 
@@ -63,7 +63,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Error::Custom(ref msg) => msg.fmt(f),
             Error::Utf8(ref err) => write!(f, "invalid UTF-8: {}", err),
@@ -80,7 +80,7 @@ impl error::Error for Error {
     }
 
     /// The lower-level cause of this error, in the case of a `Utf8` error.
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Custom(_) => None,
             Error::Utf8(ref err) => Some(err),
@@ -103,46 +103,46 @@ impl ser::Error for Error {
 }
 
 /// Sequence serializer.
-pub struct SeqSerializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+pub struct SeqSerializer<'input, 'output, Target: UrlEncodedTarget> {
     urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
 }
 
 /// Tuple serializer.
 ///
 /// Mostly used for arrays.
-pub struct TupleSerializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+pub struct TupleSerializer<'input, 'output, Target: UrlEncodedTarget> {
     urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
 }
 
 /// Tuple struct serializer.
 ///
 /// Never instantiated, tuple structs are not supported.
-pub struct TupleStructSerializer<'input, 'output, T: 'output + UrlEncodedTarget> {
+pub struct TupleStructSerializer<'input, 'output, T: UrlEncodedTarget> {
     inner: ser::Impossible<&'output mut UrlEncodedSerializer<'input, T>, Error>,
 }
 
 /// Tuple variant serializer.
 ///
 /// Never instantiated, tuple variants are not supported.
-pub struct TupleVariantSerializer<'input, 'output, T: 'output + UrlEncodedTarget> {
+pub struct TupleVariantSerializer<'input, 'output, T: UrlEncodedTarget> {
     inner: ser::Impossible<&'output mut UrlEncodedSerializer<'input, T>, Error>,
 }
 
 /// Map serializer.
-pub struct MapSerializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+pub struct MapSerializer<'input, 'output, Target: UrlEncodedTarget> {
     urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
     key: Option<Cow<'static, str>>,
 }
 
 /// Struct serializer.
-pub struct StructSerializer<'input, 'output, Target: 'output + UrlEncodedTarget> {
+pub struct StructSerializer<'input, 'output, Target: UrlEncodedTarget> {
     urlencoder: &'output mut UrlEncodedSerializer<'input, Target>,
 }
 
 /// Struct variant serializer.
 ///
 /// Never instantiated, struct variants are not supported.
-pub struct StructVariantSerializer<'input, 'output, T: 'output + UrlEncodedTarget> {
+pub struct StructVariantSerializer<'input, 'output, T: UrlEncodedTarget> {
     inner: ser::Impossible<&'output mut UrlEncodedSerializer<'input, T>, Error>,
 }
 

--- a/src/ser/pair.rs
+++ b/src/ser/pair.rs
@@ -1,14 +1,14 @@
 use form_urlencoded::Serializer as UrlEncodedSerializer;
 use form_urlencoded::Target as UrlEncodedTarget;
-use ser::key::KeySink;
-use ser::part::PartSerializer;
-use ser::value::ValueSink;
-use ser::Error;
+use crate::ser::key::KeySink;
+use crate::ser::part::PartSerializer;
+use crate::ser::value::ValueSink;
+use crate::ser::Error;
 use serde::ser;
 use std::borrow::Cow;
 use std::mem;
 
-pub struct PairSerializer<'input, 'target, Target: 'target + UrlEncodedTarget> {
+pub struct PairSerializer<'input, 'target, Target: UrlEncodedTarget> {
     urlencoder: &'target mut UrlEncodedSerializer<'input, Target>,
     state: PairState,
 }

--- a/src/ser/pair.rs
+++ b/src/ser/pair.rs
@@ -19,7 +19,7 @@ where
 {
     pub fn new(urlencoder: &'target mut UrlEncodedSerializer<'input, Target>) -> Self {
         PairSerializer {
-            urlencoder: urlencoder,
+            urlencoder,
             state: PairState::WaitingForKey,
         }
     }
@@ -229,7 +229,7 @@ where
                 if result.is_ok() {
                     self.state = PairState::Done;
                 } else {
-                    self.state = PairState::WaitingForValue { key: key };
+                    self.state = PairState::WaitingForValue { key };
                 }
                 result
             },

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -1,6 +1,4 @@
 use crate::ser::Error;
-use itoa;
-use ryu;
 use serde::ser;
 use std::str;
 
@@ -10,7 +8,7 @@ pub struct PartSerializer<S> {
 
 impl<S: Sink> PartSerializer<S> {
     pub fn new(sink: S) -> Self {
-        PartSerializer { sink: sink }
+        PartSerializer { sink }
     }
 }
 
@@ -110,7 +108,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<S::Ok, Error> {
-        self.sink.serialize_static_str(name.into())
+        self.sink.serialize_static_str(name)
     }
 
     fn serialize_unit_variant(
@@ -119,7 +117,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<S::Ok, Error> {
-        self.sink.serialize_static_str(variant.into())
+        self.sink.serialize_static_str(variant)
     }
 
     fn serialize_newtype_struct<T: ?Sized + ser::Serialize>(

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -1,6 +1,6 @@
+use crate::ser::Error;
 use itoa;
 use ryu;
-use ser::Error;
 use serde::ser;
 use std::str;
 

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -1,13 +1,13 @@
 use form_urlencoded::Serializer as UrlEncodedSerializer;
 use form_urlencoded::Target as UrlEncodedTarget;
-use ser::part::{PartSerializer, Sink};
-use ser::Error;
+use crate::ser::part::{PartSerializer, Sink};
+use crate::ser::Error;
 use serde::ser::Serialize;
 use std::str;
 
 pub struct ValueSink<'input, 'key, 'target, Target>
 where
-    Target: 'target + UrlEncodedTarget,
+    Target: UrlEncodedTarget,
 {
     urlencoder: &'target mut UrlEncodedSerializer<'input, Target>,
     key: &'key str,

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -21,10 +21,7 @@ where
         urlencoder: &'target mut UrlEncodedSerializer<'input, Target>,
         key: &'key str,
     ) -> Self {
-        ValueSink {
-            urlencoder: urlencoder,
-            key: key,
-        }
+        ValueSink { urlencoder, key }
     }
 }
 

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -1,6 +1,4 @@
-extern crate serde_urlencoded;
-#[macro_use]
-extern crate serde_derive;
+use serde_derive::Deserialize;
 
 #[derive(Deserialize, Debug, PartialEq)]
 struct NewType<T>(T);

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -1,6 +1,4 @@
-extern crate serde_urlencoded;
-#[macro_use]
-extern crate serde_derive;
+use serde_derive::Serialize;
 
 #[derive(Serialize)]
 struct NewType<T>(T);


### PR DESCRIPTION
#70 is missing changes for edition 2018
The `edition="2018"` entry in `Cargo.toml` and `cargo fix --edition-idioms`