### PR TITLE
Require at least serde 1.0.69

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ test = false
 form_urlencoded = "1"
 itoa = "0.4"
 ryu = "1"
-serde = "1"
+serde = "1.0.69"
 
 [dev-dependencies]
 serde_derive = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "serde_urlencoded"
-version = "0.7.0" # bump in documentation link and in README on update
+version = "0.7.1" # bump in documentation link and in README on update
 authors = ["Anthony Ramine <n.oxyde@gmail.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/nox/serde_urlencoded"
-documentation = "https://docs.rs/serde_urlencoded/0.7.0/serde_urlencoded/"
+documentation = "https://docs.rs/serde_urlencoded/0.7.1/serde_urlencoded/"
 description = "`x-www-form-urlencoded` meets Serde"
 categories = ["encoding", "web-programming"]
 keywords = ["serde", "serialization", "urlencoded"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ serde_urlencoded = "0.7"
 The documentation is available on [docs.rs].
 
 [crates.io]: https://crates.io/crates/serde_urlencoded
-[docs.rs]: https://docs.rs/serde_urlencoded/0.7.0/serde_urlencoded/
+[docs.rs]: https://docs.rs/serde_urlencoded/0.7.1/serde_urlencoded/
 
 ## Getting help
 


### PR DESCRIPTION
serde 1 version requirement is not correct, as it's incompatible with edition 2018 used by this crate. serde 1.0.69 is the first version to work when `forward_to_deserialize_any` is imported without using `#[macro_use]`. This causes issues with `cargo update -Z minimal-versions`