### PR TITLE
Add support for serializing `i128`/`u128` values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
        rustup component add rustfmt
        cargo fmt --all -- --check
      fi
-  - cargo build -v
-  - cargo test -v
+  - cargo build --features=i128 -v
+  - cargo test --features=i128 -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ travis-ci = {repository = "nox/serde_urlencoded"}
 [lib]
 test = false
 
+[features]
+default = []
+i128 = ["itoa/i128"]
+
 [dependencies]
 form_urlencoded = "1"
 itoa = "0.4"

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -80,6 +80,16 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         self.serialize_integer(v)
     }
 
+    #[cfg(feature = "i128")]
+    fn serialize_u128(self, v: u128) -> Result<S::Ok, Error> {
+        self.serialize_integer(v)
+    }
+
+    #[cfg(feature = "i128")]
+    fn serialize_i128(self, v: i128) -> Result<S::Ok, Error> {
+        self.serialize_integer(v)
+    }
+
     fn serialize_f32(self, v: f32) -> Result<S::Ok, Error> {
         self.serialize_floating(v)
     }
@@ -212,7 +222,7 @@ impl<S: Sink> PartSerializer<S> {
     where
         I: itoa::Integer,
     {
-        let mut buf = [b'\0'; 20];
+        let mut buf = [b'\0'; 40];
         let len = itoa::write(&mut buf[..], value).unwrap();
         let part = unsafe { str::from_utf8_unchecked(&buf[0..len]) };
         ser::Serializer::serialize_str(self, part)

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -12,6 +12,26 @@ fn serialize_newtype_i32() {
     );
 }
 
+#[cfg(feature = "i128")]
+#[test]
+fn serialize_newtype_u128() {
+    let params = &[("field", Some(NewType(u128::MAX)))];
+    assert_eq!(
+        serde_urlencoded::to_string(params),
+        Ok(format!("field={}", u128::MAX))
+    );
+}
+
+#[cfg(feature = "i128")]
+#[test]
+fn serialize_newtype_i128() {
+    let params = &[("field", Some(NewType(i128::MIN)))];
+    assert_eq!(
+        serde_urlencoded::to_string(params),
+        Ok(format!("field={}", i128::MIN))
+    );
+}
+
 #[test]
 fn serialize_option_map_int() {
     let params = &[("first", Some(23)), ("middle", None), ("last", Some(42))];


### PR DESCRIPTION
The crate currently fails serialization of 128 bit wide integers. That
is very unfortunate, because `SystemTime` values converted to
milliseconds, for example, are natively expressed as objects of such a
type.
`itoa` already supports such wide integer types, guarded by the i128
feature. With this change we introduce a similar feature and add support
for such a conversion.