### PR TITLE
Forbid use of unsafe code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ test = false
 
 [dependencies]
 form_urlencoded = "1"
-itoa = "0.4"
+itoa = "1"
 ryu = "1"
 serde = "1.0.69"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! `x-www-form-urlencoded` meets Serde
 
 #![warn(unused_extern_crates)]
+#![forbid(unsafe_code)]
 
 pub mod de;
 pub mod ser;

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -212,9 +212,8 @@ impl<S: Sink> PartSerializer<S> {
     where
         I: itoa::Integer,
     {
-        let mut buf = [b'\0'; 20];
-        let len = itoa::write(&mut buf[..], value).unwrap();
-        let part = unsafe { str::from_utf8_unchecked(&buf[0..len]) };
+        let mut buf = itoa::Buffer::new();
+        let part = buf.format(value);
         ser::Serializer::serialize_str(self, part)
     }
 


### PR DESCRIPTION
Depends on #94, which removes the only use of unsafe