### PR TITLE
Fix typo

### DIFF
--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -175,7 +175,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         self,
         _name: &'static str,
         _len: usize,
-    ) -> Result<Self::SerializeTuple, Error> {
+    ) -> Result<Self::SerializeTupleStruct, Error> {
         Err(self.sink.unsupported())
     }
 


### PR DESCRIPTION
[`serialize_tuple_struct`] must return Result<Self::SerializeTupleStruct, Error>, not Result<Self::SerializeTuple, Error>

It doesn't really matter, because both types are impossible. But when I looked at the source code it confused me.

[`serialize_tuple_struct`]: https://github.com/nox/serde_urlencoded/blob/d8bc15d16adf6b3ba6ae46d199d7109cf5079efa/src/ser/part.rs#L174