### PR TITLE
Add type info to 'unsupported' error messages

### DIFF
--- a/src/ser/key.rs
+++ b/src/ser/key.rs
@@ -61,17 +61,17 @@ where
     }
 
     fn serialize_none(self) -> Result<Ok, Error> {
-        Err(self.unsupported())
+        Err(self.unsupported("none"))
     }
 
     fn serialize_some<T: ?Sized + Serialize>(
         self,
         _value: &T,
     ) -> Result<Ok, Error> {
-        Err(self.unsupported())
+        Err(self.unsupported("some"))
     }
 
-    fn unsupported(self) -> Error {
-        Error::Custom("unsupported key".into())
+    fn unsupported(self, type_str: &'static str) -> Error {
+        Error::Custom(format!("unsupported key type: {type_str}").into())
     }
 }

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -29,7 +29,7 @@ pub trait Sink: Sized {
         value: &T,
     ) -> Result<Self::Ok, Error>;
 
-    fn unsupported(self) -> Error;
+    fn unsupported(self, type_str: &'static str) -> Error;
 }
 
 impl<S: Sink> ser::Serializer for PartSerializer<S> {
@@ -112,7 +112,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
     }
 
     fn serialize_unit(self) -> Result<S::Ok, Error> {
-        Err(self.sink.unsupported())
+        Err(self.sink.unsupported("unit"))
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<S::Ok, Error> {
@@ -143,7 +143,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         _variant: &'static str,
         _value: &T,
     ) -> Result<S::Ok, Error> {
-        Err(self.sink.unsupported())
+        Err(self.sink.unsupported("newtype variant"))
     }
 
     fn serialize_none(self) -> Result<S::Ok, Error> {
@@ -161,14 +161,14 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         self,
         _len: Option<usize>,
     ) -> Result<Self::SerializeSeq, Error> {
-        Err(self.sink.unsupported())
+        Err(self.sink.unsupported("sequence"))
     }
 
     fn serialize_tuple(
         self,
         _len: usize,
     ) -> Result<Self::SerializeTuple, Error> {
-        Err(self.sink.unsupported())
+        Err(self.sink.unsupported("tuple"))
     }
 
     fn serialize_tuple_struct(
@@ -176,7 +176,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTuple, Error> {
-        Err(self.sink.unsupported())
+        Err(self.sink.unsupported("tuple struct"))
     }
 
     fn serialize_tuple_variant(
@@ -186,14 +186,14 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant, Error> {
-        Err(self.sink.unsupported())
+        Err(self.sink.unsupported("tuple variant"))
     }
 
     fn serialize_map(
         self,
         _len: Option<usize>,
     ) -> Result<Self::SerializeMap, Error> {
-        Err(self.sink.unsupported())
+        Err(self.sink.unsupported("map"))
     }
 
     fn serialize_struct(
@@ -201,7 +201,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         _name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStruct, Error> {
-        Err(self.sink.unsupported())
+        Err(self.sink.unsupported("struct"))
     }
 
     fn serialize_struct_variant(
@@ -211,7 +211,7 @@ impl<S: Sink> ser::Serializer for PartSerializer<S> {
         _variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Error> {
-        Err(self.sink.unsupported())
+        Err(self.sink.unsupported("struct variant"))
     }
 }
 

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -56,7 +56,7 @@ where
         value.serialize(PartSerializer::new(self))
     }
 
-    fn unsupported(self) -> Error {
-        Error::Custom("unsupported value".into())
+    fn unsupported(self, type_str: &'static str) -> Error {
+        Error::Custom(format!("unsupported value type: {type_str}").into())
     }
 }

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -102,3 +102,32 @@ fn serialize_unit_struct() {
 fn serialize_unit_type() {
     assert_eq!(serde_urlencoded::to_string(()), Ok("".to_owned()));
 }
+
+#[derive(Serialize)]
+struct ListStruct<T> {
+    x: Vec<T>,
+    y: Vec<T>,
+}
+
+#[test]
+#[should_panic(
+    expected = r#"called `Result::unwrap()` on an `Err` value: Custom("unsupported value type: sequence")"#
+)]
+fn value_type_error_msg() {
+    let list_struct = ListStruct {
+        x: vec![1, 2, 3],
+        y: vec![4, 5, 6],
+    };
+    let _ = serde_urlencoded::to_string(list_struct).unwrap();
+}
+
+#[test]
+#[should_panic(
+    expected = r#"called `Result::unwrap()` on an `Err` value: Custom("unsupported key type: sequence")"#
+)]
+fn key_type_error_msg() {
+    use std::collections::HashMap;
+
+    let mut map = HashMap::from([(vec![1, 2, 3], "value")]);
+    let _ = serde_urlencoded::to_string(map).unwrap();
+}


### PR DESCRIPTION
# Goal
Improve user experience by adding type information to error messages for unsupported types.

# Result
Type information is included in unsupported error messages. For example, serializing a struct containing a sequence generates the following error: `unsupported value type: sequence`.

# Testing
Two very small unit tests have been added to ensure that unsupported key types and unsupported value types generate appropriate errors.

# Notes
I have not included any error messaging for deserialization, but could do so if desired.