### PR TITLE
Deserilize values with identical names as a sequence

### DIFF
--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -97,3 +97,25 @@ fn deserialize_128bit() {
     let q = format!("min={}", i128::MIN);
     assert_eq!(serde_urlencoded::from_str(&q), Ok(result));
 }
+
+#[derive(Deserialize, Debug, PartialEq, Eq)]
+struct Nums {
+    num: Vec<u8>,
+}
+
+#[test]
+fn deserialize_repeated_name() {
+    let result = Nums { num: vec![] };
+    assert_eq!(serde_urlencoded::from_str("num="), Ok(result));
+
+    let result = Nums { num: vec![1] };
+    assert_eq!(serde_urlencoded::from_str("num=1"), Ok(result));
+
+    let result = Nums { num: vec![1, 2] };
+    assert_eq!(serde_urlencoded::from_str("num=1&num=2"), Ok(result));
+
+    assert!(serde_urlencoded::from_str::<Nums>(
+        "num=1&num=2&another=thing&num=3"
+    )
+    .is_err());
+}


### PR DESCRIPTION
This PR adds support for deserializing values with the same name as a vector.
```rust
#[derive(Deserialize, Debug, PartialEq, Eq)]
struct Options {
    option: Vec<String>,
}

let options =
    serde_urlencoded::from_str::<Options>("option=first&option=second");

assert_eq!(
    options,
    Ok(Options {
        option: vec!["first".to_owned(), "second".to_owned()],
    }),
);
```

Using repeated keys is a common convention used to represent lists in a `x-www-form-urlencoded` form, i think it would be a valuable addition to this library.

I am sure the implementation included in this PR is not the best way to do this but i will be happy to correct it based on your review.