### PR TITLE
Add `#![no_std]` Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,17 @@ travis-ci = {repository = "nox/serde_urlencoded"}
 [lib]
 test = false
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
-form_urlencoded = "1"
+form_urlencoded = { version = "1", default_features = false, features = [
+	"alloc",
+] }
 itoa = "1"
 ryu = "1"
-serde = "1.0.69"
+serde = { version = "1.0.69", default_features = false, features = ["alloc"] }
 
 [dev-dependencies]
 serde_derive = "1"

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,13 +1,12 @@
 //! Deserialization support for the `application/x-www-form-urlencoded` format.
 
+use alloc::borrow::Cow;
 use form_urlencoded::parse;
 use form_urlencoded::Parse as UrlEncodedParse;
 use serde::de::value::MapDeserializer;
 use serde::de::Error as de_Error;
 use serde::de::{self, IntoDeserializer};
 use serde::forward_to_deserialize_any;
-use std::borrow::Cow;
-use std::io::Read;
 
 #[doc(inline)]
 pub use serde::de::value::Error;
@@ -58,12 +57,15 @@ where
 
 /// Convenience function that reads all bytes from `reader` and deserializes
 /// them with `from_bytes`.
+#[cfg(feature = "std")]
 pub fn from_reader<T, R>(mut reader: R) -> Result<T, Error>
 where
     T: de::DeserializeOwned,
-    R: Read,
+    R: std::io::Read,
 {
-    let mut buf = vec![];
+    use alloc::vec::Vec;
+
+    let mut buf = Vec::new();
     reader.read_to_end(&mut buf).map_err(|e| {
         de::Error::custom(format_args!("could not read input: {}", e))
     })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,20 @@
 //! `x-www-form-urlencoded` meets Serde
-
+#![no_std]
 #![warn(unused_extern_crates)]
 #![forbid(unsafe_code)]
+
+extern crate alloc;
+
+#[cfg(feature = "std")]
+extern crate std;
 
 pub mod de;
 pub mod ser;
 
+#[cfg(feature = "std")]
 #[doc(inline)]
-pub use crate::de::{from_bytes, from_reader, from_str, Deserializer};
+pub use crate::de::from_reader;
+#[doc(inline)]
+pub use crate::de::{from_bytes, from_str, Deserializer};
 #[doc(inline)]
 pub use crate::ser::{to_string, Serializer};

--- a/src/ser/key.rs
+++ b/src/ser/key.rs
@@ -1,8 +1,10 @@
 use crate::ser::part::Sink;
 use crate::ser::Error;
+use alloc::borrow::Cow;
+use alloc::format;
+use alloc::string::String;
+use core::ops::Deref;
 use serde::Serialize;
-use std::borrow::Cow;
-use std::ops::Deref;
 
 pub enum Key<'key> {
     Static(&'static str),

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -5,13 +5,15 @@ mod pair;
 mod part;
 mod value;
 
+use alloc::borrow::Cow;
+use alloc::borrow::ToOwned;
+use alloc::format;
+use alloc::string::String;
+use core::fmt;
+use core::str;
 use form_urlencoded::Serializer as UrlEncodedSerializer;
 use form_urlencoded::Target as UrlEncodedTarget;
 use serde::ser;
-use std::borrow::Cow;
-use std::error;
-use std::fmt;
-use std::str;
 
 /// Serializes a value into a `application/x-www-form-urlencoded` `String` buffer.
 ///
@@ -73,16 +75,17 @@ impl fmt::Display for Error {
     }
 }
 
-impl error::Error for Error {
+#[cfg(feature = "std")]
+impl std::error::Error for Error {
     fn description(&self) -> &str {
         match *self {
             Error::Custom(ref msg) => msg,
-            Error::Utf8(ref err) => error::Error::description(err),
+            Error::Utf8(ref err) => std::error::Error::description(err),
         }
     }
 
     /// The lower-level cause of this error, in the case of a `Utf8` error.
-    fn cause(&self) -> Option<&dyn error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::Custom(_) => None,
             Error::Utf8(ref err) => Some(err),
@@ -90,7 +93,7 @@ impl error::Error for Error {
     }
 
     /// The lower-level source of this error, in the case of a `Utf8` error.
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match *self {
             Error::Custom(_) => None,
             Error::Utf8(ref err) => Some(err),

--- a/src/ser/pair.rs
+++ b/src/ser/pair.rs
@@ -2,11 +2,11 @@ use crate::ser::key::KeySink;
 use crate::ser::part::PartSerializer;
 use crate::ser::value::ValueSink;
 use crate::ser::Error;
+use alloc::borrow::Cow;
+use core::mem;
 use form_urlencoded::Serializer as UrlEncodedSerializer;
 use form_urlencoded::Target as UrlEncodedTarget;
 use serde::ser;
-use std::borrow::Cow;
-use std::mem;
 
 pub struct PairSerializer<'input, 'target, Target: UrlEncodedTarget> {
     urlencoder: &'target mut UrlEncodedSerializer<'input, Target>,

--- a/src/ser/part.rs
+++ b/src/ser/part.rs
@@ -1,6 +1,8 @@
 use crate::ser::Error;
+use alloc::string::String;
+use alloc::string::ToString;
+use core::str;
 use serde::ser;
-use std::str;
 
 pub struct PartSerializer<S> {
     sink: S,

--- a/src/ser/value.rs
+++ b/src/ser/value.rs
@@ -1,9 +1,11 @@
 use crate::ser::part::{PartSerializer, Sink};
 use crate::ser::Error;
+use alloc::format;
+use alloc::string::String;
+use core::str;
 use form_urlencoded::Serializer as UrlEncodedSerializer;
 use form_urlencoded::Target as UrlEncodedTarget;
 use serde::ser::Serialize;
-use std::str;
 
 pub struct ValueSink<'input, 'key, 'target, Target>
 where


### PR DESCRIPTION
This PR makes this crate `#![no_std]` and adds a `"std"` feature for the `std::error::Error` impl on the `Error` enum and the `from_reader` function. The new feature `"std"` is a default feature to enable all current features by default.
